### PR TITLE
Fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ impl<'a> Interop for *const libc::c_void {
     }
 }
 
+#[macro_export]
 macro_rules! js {
     ( ($( $x:expr ),*) $y:expr ) => {
         {
@@ -211,7 +212,7 @@ impl<'a> HtmlNode<'a> {
             })
         }
     }
-    
+
     pub fn data_set(&self, s: &str, v: &str) {
         js! { (self.id, s, v) br#"
             WEBPLATFORM.rs_refs[$0].dataset[UTF8ToString($1)] = UTF8ToString($2);
@@ -232,7 +233,7 @@ impl<'a> HtmlNode<'a> {
             })
         }
     }
-    
+
     pub fn style_set_str(&self, s: &str, v: &str) {
         js! { (self.id, s, v) br#"
             WEBPLATFORM.rs_refs[$0].style[UTF8ToString($1)] = UTF8ToString($2);
@@ -247,25 +248,25 @@ impl<'a> HtmlNode<'a> {
             str::from_utf8(CStr::from_ptr(a as *const libc::c_char).to_bytes()).unwrap().to_owned()
         }
     }
-    
+
     pub fn prop_set_i32(&self, s: &str, v: i32) {
         js! { (self.id, s, v) br#"
             WEBPLATFORM.rs_refs[$0][UTF8ToString($1)] = $2;
         "#};
     }
-    
+
     pub fn prop_set_str(&self, s: &str, v: &str) {
         js! { (self.id, s, v) br#"
             WEBPLATFORM.rs_refs[$0][UTF8ToString($1)] = UTF8ToString($2);
         "#};
     }
-    
+
     pub fn prop_get_i32(&self, s: &str) -> i32 {
         return js! { (self.id, s) br#"
             return Number(WEBPLATFORM.rs_refs[$0][UTF8ToString($1)])
         "#};
     }
-    
+
     pub fn prop_get_str(&self, s: &str) -> String {
         let a = js! { (self.id, s) br#"
             return allocate(intArrayFromString(WEBPLATFORM.rs_refs[$0][UTF8ToString($1)]), 'i8', ALLOC_STACK);
@@ -510,7 +511,7 @@ extern fn leavemebe() {
 pub fn spin() {
     unsafe {
         emscripten_set_main_loop(leavemebe, 0, 1);
-        
+
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
 
         let bodyref = body.root_ref();
         let bodyref2 = body.root_ref();
-    	button.on("click", move || {
+        button.on("click", move |_| {
             bodyref2.prop_set_str("bgColor", "blue");
         });
         

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 #![plugin(concat_bytes)]
 
 #[macro_use] extern crate webplatform;
+extern crate libc;
 
 use std::borrow::ToOwned;
 
@@ -24,10 +25,10 @@ fn main() {
         button.on("click", move |_| {
             bodyref2.prop_set_str("bgColor", "blue");
         });
-        
+
         println!("This should be blue: {:?}", bodyref.prop_get_str("bgColor"));
         println!("Width?: {:?}", bodyref.prop_get_i32("clientWidth"));
-    
+
         webplatform::spin();
     }
 


### PR DESCRIPTION
- Actually export the `js!` macro to make it usable by user code. This means user code must also use `extern crate libc` to get the `libc::` types
- The closure on `.on` takes a parameter. The example file doesn't use it, so it can just be dropped.
