### PR TITLE
Fully qualify paths used in js macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "webplatform"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]


### PR DESCRIPTION
This change makes it possible to use the `js!` macro from another crate. Previously, the macro used the un-exported `Interop` trait. This change exports the `Interop` trait and reexports the required `libc` types. It also fully qualifies all paths used in the macro so that the user doesn't have to manually `use` the types.